### PR TITLE
Endpoint pages don't have copiable URLs

### DIFF
--- a/api-playground/static/js/embedded.js
+++ b/api-playground/static/js/embedded.js
@@ -73,6 +73,8 @@ window.addEventListener('hashchange', (e) => {
   if (!shouldPatch) {
     return;
   }
+  const queryParams = window.location.href.split("#/")[1];
+  window.parent.postMessage({ type: "url-change", data: queryParams }, "*");
   patchURLAndPlayground(playgroundConfig);
 });
 


### PR DESCRIPTION
[REST API v2 playground] Endpoint pages don't have copiable URLs 
Implementation to update the URL