### PR TITLE
Sending ready message once portal is ready

### DIFF
--- a/api-playground/static/js/embedded.js
+++ b/api-playground/static/js/embedded.js
@@ -52,10 +52,6 @@ const patchURLAndPlayground = async ({ baseUrl, accessToken }) => {
 const channel = new MessageChannel();
 let playgroundConfig = {};
 
-window.parent.postMessage({ type: 'api-playground-ready' }, '*', [
-  channel.port2,
-]);
-
 function getElementByIdAsync(id) {
   let maxTime = 2000;
   const STEP = 16;
@@ -77,6 +73,9 @@ const setAPIMaticPortalConfig = () => {
   APIMaticDevPortal.ready(({ setConfig }) => {
     isApiMaticPortalReady = true;
     _setConfig = setConfig;
+    window.parent.postMessage({ type: 'api-playground-ready' }, '*', [
+      channel.port2,
+    ]);
   });
 };
 


### PR DESCRIPTION
Apimatic portal was not loading config for many customers ,
It looks like we are prematurely sending 'api-playground-ready' , so even if we are setting config its not getting set cause isApiMaticPortalReady is false ,
So moving the send message to the .ready method provided by them fixes it.