### PR TITLE
[SCAL-299570] Add AUTHORING no-op note to privileges field descriptions

### DIFF
--- a/api-spec/openapiSpecv3-2_0.json
+++ b/api-spec/openapiSpecv3-2_0.json
@@ -17828,7 +17828,7 @@
                 "CAN_MANAGE_SPOTTER"
               ]
             },
-            "description": "Privileges granted to the role."
+            "description": "Privileges granted to the role. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect."
           },
           "permission": {
             "type": "string",
@@ -22173,7 +22173,7 @@
                 "CAN_MANAGE_SPOTTER"
               ]
             },
-            "description": "Privileges that will be assigned to the group.",
+            "description": "Privileges that will be assigned to the group. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "nullable": true
           },
           "sub_group_identifiers": {
@@ -27294,7 +27294,7 @@
             "type": "string"
           },
           "privileges": {
-            "description": "Privileges to assign to the group",
+            "description": "Privileges to assign to the group. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "type": "array",
             "items": {
               "type": "string",
@@ -27443,7 +27443,7 @@
             }
           },
           "privileges": {
-            "description": "Privileges assigned to the group.",
+            "description": "Privileges assigned to the group. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "type": "array",
             "items": {
               "type": "string",
@@ -27593,7 +27593,7 @@
             "type": "string"
           },
           "privileges": {
-            "description": "Privileges to assign to the group.",
+            "description": "Privileges to assign to the group. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "type": "array",
             "items": {
               "type": "string",
@@ -28831,7 +28831,7 @@
             }
           },
           "privileges": {
-            "description": "Privileges assigned to the Role. See [Documentation](https://developers.thoughtspot.com/docs/rbac#_role_categories_and_privileges)for supported roles privileges.",
+            "description": "Privileges assigned to the Role. See [Documentation](https://developers.thoughtspot.com/docs/rbac#_role_categories_and_privileges)for supported roles privileges. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "type": "array",
             "items": {
               "type": "string",
@@ -31498,7 +31498,7 @@
             }
           },
           "privileges": {
-            "description": "Privileges assigned to the user",
+            "description": "Privileges assigned to the user. Note: AUTHORING is a no-op — always inherited via ALL_GROUP, assigning it has no effect.",
             "type": "array",
             "items": {
               "type": "string",


### PR DESCRIPTION
Update the privileges field description across users, groups, and roles endpoints to clarify that AUTHORING is a no-op privilege — always inherited via ALL_GROUP, and assigning it has no functional effect.